### PR TITLE
Use buildSrc to manage the dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balanced.network.
+ * Copyright (c) 2022 Balanced.network.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
+import network.balanced.score.dependencies.Dependencies
+
+
+
 buildscript {
     repositories {
         mavenCentral()
     }
     dependencies {
-        classpath 'foundation.icon:gradle-javaee-plugin:0.8.0'
+        classpath Dependencies.javaeePlugin
     }
 }
 
@@ -30,10 +34,6 @@ subprojects {
 
     apply plugin: 'java'
     apply plugin: 'foundation.icon.javaee'
-
-    dependencies {
-        testImplementation group: 'org.json', name: 'json', version: '20211205'
-    }
 
     java {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/buildSrc/src/main/java/network/balanced/score/dependencies/Dependencies.java
+++ b/buildSrc/src/main/java/network/balanced/score/dependencies/Dependencies.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022-2022 Balanced.network.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package network.balanced.score.dependencies;
+
+public class Dependencies {
+
+    public static final String javaeePlugin = "foundation.icon:gradle-javaee-plugin:0.8.0";
+    public static final String javaeeApi = "foundation.icon:javaee-api:0.9.1";
+    public static final String javaeeScorex = "foundation.icon:javaee-scorex:0.5.2";
+    public static final String javaeeTokens = "com.github.sink772:javaee-tokens:0.6.1";
+    public static final String javaeeUnitTest = "foundation.icon:javaee-unittest:0.9.2";
+
+    public static final String junitJupiter = "org.junit.jupiter:junit-jupiter:5.8.2";
+    public static final String junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:5.8.2";
+    public static final String mockitoCore = "org.mockito:mockito-core:4.3.1";
+}

--- a/core-contracts/BatchDisbursement/build.gradle
+++ b/core-contracts/BatchDisbursement/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balanced.network.
+ * Copyright (c) 2022 Balanced.network.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import network.balanced.score.dependencies.Dependencies
+
+
+
 version = '0.1.0'
 
 repositories {
@@ -22,15 +26,15 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'foundation.icon:javaee-api:0.9.1'
-    implementation 'foundation.icon:javaee-scorex:0.5.2'
+    compileOnly Dependencies.javaeeApi
+    implementation Dependencies.javaeeScorex
 
-    testImplementation 'com.github.sink772:javaee-tokens:0.6.1'
-    testImplementation 'foundation.icon:javaee-unittest:0.9.2'
+    testImplementation Dependencies.javaeeTokens
+    testImplementation Dependencies.javaeeUnitTest
     // Use JUnit Jupiter for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-    testImplementation 'org.mockito:mockito-core:4.1.0'
+    testImplementation Dependencies.junitJupiter
+    testRuntimeOnly Dependencies.junitJupiterEngine
+    testImplementation Dependencies.mockitoCore
 }
 
 optimizedJar {

--- a/core-contracts/Multicall/build.gradle
+++ b/core-contracts/Multicall/build.gradle
@@ -1,6 +1,5 @@
-
 /*
- * Copyright (c) 2022-2022 Balanced.network.
+ * Copyright (c) 2022 Balanced.network.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +14,10 @@
  * limitations under the License.
  */
 
+import network.balanced.score.dependencies.Dependencies
+
+
+
 version = '0.1.0'
 
 repositories {
@@ -23,14 +26,14 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'foundation.icon:javaee-api:0.9.1'
-    implementation 'foundation.icon:javaee-scorex:0.5.2'
+    compileOnly Dependencies.javaeeApi
+    implementation Dependencies.javaeeScorex
 
-    testImplementation 'foundation.icon:javaee-unittest:0.9.2'
+    testImplementation Dependencies.javaeeUnitTest
     // Use JUnit Jupiter for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-    testImplementation 'org.mockito:mockito-core:4.1.0'
+    testImplementation Dependencies.junitJupiter
+    testRuntimeOnly Dependencies.junitJupiterEngine
+    testImplementation Dependencies.mockitoCore
 }
 
 optimizedJar {

--- a/core-contracts/Reserve/build.gradle
+++ b/core-contracts/Reserve/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2022 Balanced.network.
+ * Copyright (c) 2022 Balanced.network.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import network.balanced.score.dependencies.Dependencies
+
+
+
 version = '0.1.0'
 
 repositories {
@@ -22,14 +26,14 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'foundation.icon:javaee-api:0.9.1'
-    implementation 'foundation.icon:javaee-scorex:0.5.2'
+    compileOnly Dependencies.javaeeApi
+    implementation Dependencies.javaeeScorex
 
-    testImplementation 'foundation.icon:javaee-unittest:0.9.2'
-    testImplementation 'com.github.sink772:javaee-tokens:0.6.1'
+    testImplementation Dependencies.javaeeUnitTest
+    testImplementation Dependencies.javaeeTokens
     // Use JUnit Jupiter for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation Dependencies.junitJupiter
+    testRuntimeOnly Dependencies.junitJupiterEngine
 }
 
 optimizedJar {


### PR DESCRIPTION
* buildSrc will also be used to manage other complex tasks in Java and also manage constants.
* Custom plugins and tasks can be created in buildSrc folder
* Changing content in buildSrc invalidates the cache of build, this can be improved later by using composite build
