### PR TITLE
feat#48: translate Multicall Score from solidity to java

### DIFF
--- a/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
+++ b/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
@@ -47,6 +47,7 @@ public class Multicall {
             this.success = b;
             this.returnData = result;
         }
+
         @Keep
         public boolean success;
 
@@ -115,11 +116,11 @@ public class Multicall {
         Object[] returnData = new Object[calls.length];
 
         for (int i = 0; i < calls.length; i++) {
-            Object[] params = convertToType(calls[i].params);
             Address contractAddress = calls[i].target;
             String method = calls[i].method;
-
             try {
+                Object[] params = convertToType(calls[i].params);
+
                 if (calls[i].params.length == 0) {
                     returnData[i] = Context.call(contractAddress, method);
                 } else {
@@ -138,11 +139,10 @@ public class Multicall {
     public Map<String, Object> tryAggregate(boolean requireSuccess, Call[] calls) {
         Result[] returnData = new Result[calls.length];
         for (int i = 0; i < calls.length; i++) {
-            Object[] params = convertToType(calls[i].params);
             Address contractAddress = calls[i].target;
             String method = calls[i].method;
-
             try {
+                Object[] params = convertToType(calls[i].params);
                 Object result = new Object();
                 if (calls[i].params.length == 0) {
                     result = Context.call(contractAddress, method);

--- a/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
+++ b/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
@@ -108,7 +108,7 @@ public class Multicall {
 
     @External(readonly = true)
     public Map<String, Object> aggregate(Call[] calls) {
-        long blocklNumber = Context.getBlockHeight();
+        long blockNumber = Context.getBlockHeight();
         Object[] returnData = new Object[calls.length];
 
         for (int i = 0; i < calls.length; i++) {
@@ -127,7 +127,7 @@ public class Multicall {
                 Context.revert(e + ": Multicall aggregate: call failed " + contractAddress + " method: " + method);
             }
         }
-        return Map.of("blockNumber", blocklNumber, "returnData", returnData);
+        return Map.of("blockNumber", blockNumber, "returnData", returnData);
 
     }
 
@@ -163,12 +163,12 @@ public class Multicall {
     @External(readonly = true)
     public Map<String, Object> tryBlockAndAggregate(boolean requireSuccess,
             Call[] calls) {
-        long blocklNumber = getBlockNumber();
+        long blockNumber = getBlockNumber();
         byte[] blockHash = getLastBlockHash();
         Map<String, Object> returnData = tryAggregate(requireSuccess, calls);
 
         return Map.of(
-                "blockNumber", blocklNumber,
+                "blockNumber", blockNumber,
                 "blockHash", blockHash,
                 "returnData", returnData.get("returnData"));
     }

--- a/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
+++ b/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
@@ -35,6 +35,22 @@ public class Multicall {
     public Multicall() {
     }
 
+    public static class Call {
+        public Address target;
+        public String method;
+        public String[] params;
+    }
+
+    public static class Result {
+        public Result(boolean b, Object result) {
+            this.success = b;
+            this.returnData = result;
+        }
+
+        public boolean success;
+        public Object returnData;
+    }
+
     private void onlyOwner() {
         Address caller = Context.getCaller();
         Address owner = Context.getOwner();
@@ -72,6 +88,119 @@ public class Multicall {
         poolStatsWithId.putAll(poolStats);
 
         return poolStatsWithId;
+    }
+
+    private static Object[] convertToType(String[] params) {
+        Object[] results = new Object[params.length];
+        for (int i = 0; i < params.length; i++) {
+            if (params[i].startsWith("hx") || params[i].startsWith("cx")) {
+                results[i] = Address.fromString(params[i]);
+            } else if (params[i].equals("false") || params[i].equals("true")) {
+                results[i] = Boolean.parseBoolean(params[i]);
+            } else if (params[i].startsWith("0x")) {
+                results[i] = Long.decode(params[i]).longValue();
+            } else {
+                results[i] = params[i];
+            }
+        }
+        return results;
+    }
+
+    @External(readonly = true)
+    public Map<String, Object> aggregate(Call[] calls) {
+        long blocklNumber = Context.getBlockHeight();
+        Object[] returnData = new Object[calls.length];
+
+        for (int i = 0; i < calls.length; i++) {
+            Object[] params = convertToType(calls[i].params);
+            Address contractAddress = calls[i].target;
+            String method = calls[i].method;
+
+            try {
+                if (calls[i].params.length == 0) {
+                    returnData[i] = Context.call(contractAddress, method);
+                } else {
+                    returnData[i] = Context.call(contractAddress, method, params);
+                }
+            } catch (Exception e) {
+                Context.println(e.getMessage());
+                Context.revert(e + ": Multicall aggregate: call failed " + contractAddress + " method: " + method);
+            }
+        }
+        return Map.of("blockNumber", blocklNumber, "returnData", returnData);
+
+    }
+
+    @External(readonly = true)
+    public Map<String, Object> tryAggregate(boolean requireSuccess, Call[] calls) {
+        Result[] returnData = new Result[calls.length];
+        for (int i = 0; i < calls.length; i++) {
+            Object[] params = convertToType(calls[i].params);
+            Address contractAddress = calls[i].target;
+            String method = calls[i].method;
+
+            try {
+                Object result = new Object();
+                if (calls[i].params.length == 0) {
+                    result = Context.call(contractAddress, method);
+                } else {
+                    result = Context.call(contractAddress, method, params);
+                }
+                returnData[i] = new Result(Boolean.TRUE, result);
+            } catch (Exception e) {
+                String errMessage = "Multicall tryAggregate: call failed " + contractAddress + " method: " + method;
+                if (requireSuccess) {
+                    Context.println(e.getMessage());
+                    Context.revert(
+                            e + ": " + errMessage);
+                }
+                returnData[i] = new Result(Boolean.FALSE, errMessage);
+            }
+        }
+        return Map.of("returnData", returnData);
+    }
+
+    @External(readonly = true)
+    public Map<String, Object> tryBlockAndAggregate(boolean requireSuccess,
+            Call[] calls) {
+        long blocklNumber = getBlockNumber();
+        byte[] blockHash = getLastBlockHash();
+        Map<String, Object> returnData = tryAggregate(requireSuccess, calls);
+
+        return Map.of(
+                "blockNumber", blocklNumber,
+                "blockHash", blockHash,
+                "returnData", returnData.get("returnData"));
+    }
+
+    @External(readonly = true)
+    public Map<String, Object> blockAndAggregate(Call[] calls) {
+        return tryBlockAndAggregate(Boolean.TRUE, calls);
+    }
+
+    @External(readonly = true)
+    public BigInteger getBalance(Address addr) {
+        return Context.getBalance(addr);
+    }
+
+    @External(readonly = true)
+    public byte[] getBlockHash(long blockNumber) {
+        return Context.hash("sha3-256", BigInteger.valueOf(blockNumber).toByteArray());
+    }
+
+    @External(readonly = true)
+    public byte[] getLastBlockHash() {
+        return Context.hash("sha3-256", BigInteger.valueOf(Context.getBlockHeight() - 1).toByteArray());
+    }
+
+    @External(readonly = true)
+    public long getCurrentBlockTimestamp() {
+        return Context.getBlockTimestamp();
+    }
+
+    @External(readonly = true)
+    public long getBlockNumber() {
+        return Context.getBlockHeight();
     }
 
 }

--- a/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
+++ b/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
@@ -98,7 +98,7 @@ public class Multicall {
             } else if (params[i].equals("false") || params[i].equals("true")) {
                 results[i] = Boolean.parseBoolean(params[i]);
             } else if (params[i].startsWith("0x")) {
-                results[i] = Long.decode(params[i]).longValue();
+                results[i] = new BigInteger(params[i].substring(2), 16);
             } else {
                 results[i] = params[i];
             }

--- a/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
+++ b/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
@@ -163,38 +163,10 @@ public class Multicall {
         return Map.of("returnData", returnData);
     }
 
-    @External(readonly = true)
-
-    public Map<String, Object> tryBlockAndAggregate(boolean requireSuccess,
-            Call[] calls) {
-        long blockNumber = getBlockNumber();
-        byte[] blockHash = getLastBlockHash();
-        Map<String, Object> returnData = tryAggregate(requireSuccess, calls);
-
-        return Map.of(
-                "blockNumber", blockNumber,
-                "blockHash", blockHash,
-                "returnData", returnData.get("returnData"));
-    }
-
-    @External(readonly = true)
-    public Map<String, Object> blockAndAggregate(Call[] calls) {
-        return tryBlockAndAggregate(Boolean.TRUE, calls);
-    }
 
     @External(readonly = true)
     public BigInteger getBalance(Address addr) {
         return Context.getBalance(addr);
-    }
-
-    @External(readonly = true)
-    public byte[] getBlockHash(long blockNumber) {
-        return Context.hash("sha3-256", BigInteger.valueOf(blockNumber).toByteArray());
-    }
-
-    @External(readonly = true)
-    public byte[] getLastBlockHash() {
-        return Context.hash("sha3-256", BigInteger.valueOf(Context.getBlockHeight() - 1).toByteArray());
     }
 
     @External(readonly = true)

--- a/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
+++ b/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
@@ -20,6 +20,7 @@ import score.Address;
 import score.Context;
 import score.VarDB;
 import score.annotation.External;
+import score.annotation.Keep;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -132,6 +133,7 @@ public class Multicall {
     }
 
     @External(readonly = true)
+    @Keep
     public Map<String, Object> tryAggregate(boolean requireSuccess, Call[] calls) {
         Result[] returnData = new Result[calls.length];
         for (int i = 0; i < calls.length; i++) {
@@ -161,6 +163,7 @@ public class Multicall {
     }
 
     @External(readonly = true)
+    @Keep
     public Map<String, Object> tryBlockAndAggregate(boolean requireSuccess,
             Call[] calls) {
         long blockNumber = getBlockNumber();

--- a/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
+++ b/core-contracts/Multicall/src/main/java/network/balanced/score/core/multicall/Multicall.java
@@ -47,8 +47,10 @@ public class Multicall {
             this.success = b;
             this.returnData = result;
         }
-
+        @Keep
         public boolean success;
+
+        @Keep
         public Object returnData;
     }
 
@@ -133,7 +135,6 @@ public class Multicall {
     }
 
     @External(readonly = true)
-    @Keep
     public Map<String, Object> tryAggregate(boolean requireSuccess, Call[] calls) {
         Result[] returnData = new Result[calls.length];
         for (int i = 0; i < calls.length; i++) {
@@ -163,7 +164,7 @@ public class Multicall {
     }
 
     @External(readonly = true)
-    @Keep
+
     public Map<String, Object> tryBlockAndAggregate(boolean requireSuccess,
             Call[] calls) {
         long blockNumber = getBlockNumber();


### PR DESCRIPTION
- [x] translate Multicall Score from solidity to Java
## How to test
- Create a JSON file at the root folder with content as below
- Run with command
```
goloop rpc --uri https://sejong.net.solidwallet.io/api/v3/ call --to <your_contract_address> --method <contract_method> --raw './<your_json_file>.json'
```
_JSON file_
```
# this JSON file used to test for method tryBlockAndAggregate
{
  "params": {
    "calls": [
      {
        "target": "cxe801ed2f63427b0ea0520312381dba898bc11f70",
        "method": "getBlockHash",
        "params": ["0x53CFAA"]
      },
      {
        "target": "cx75256fadf232ad1124d9c6cd70c9b1ec122a0f47",
        "method": "getPoolStatsForPair",
        "params": ["cx70806fdfa274fe12ab61f1f98c5a7a1409a0c108","cx5838cb516d6156a060f90e9a3de92381331ff024"]
      },
      {
        "target": "cxe801ed2f63427b0ea0520312381dba898bc11f70",
        "method": "getBalance",
        "params": ["hx5a05b58a25a1e5ea0f1d5715e1f655dffc1fb30a"]
      }
    ],
    "requireSuccess": "0x0"
  }
}
```

Note: If you want to test with method `aggregate` please remove out **requireSuccess**  property

## Example 
I have deploy Multicall on Sejong testnet and the contract address is: `cx02510602b5f028ee418fc5a8ba893aa2dbb56ece`
```
goloop rpc --uri https://sejong.net.solidwallet.io/api/v3/ call --to cx02510602b5f028ee418fc5a8ba893aa2dbb56ece --method tryBlockAndAggregate --raw './params.json'
```

## Params:
Use this table to fill the param in JSON file

| Type  | Params  | Note  |  
|---|---|---|
| string | ["text"]  |   | 
| boolean  | ["true", "false"]  |  Values of boolean type should convert to string |   
| number | ["0x1","0xA"] | Convert number to hex (start with `0x`)  |   
| address |  ["hx....","cx...."] | Start with `hx` or `cx` |  

**Note**: This table apply to the param in `calls`. With the param outside `calls` we fill it like normally

## Ref
#48 