### PR TITLE
Add the missing fallback method to accept icx from dex

### DIFF
--- a/core-contracts/Router/src/main/java/network/balanced/score/core/router/RouterImpl.java
+++ b/core-contracts/Router/src/main/java/network/balanced/score/core/router/RouterImpl.java
@@ -243,4 +243,9 @@ public class RouterImpl implements Router {
         Address fromToken = Context.getCaller();
         route(receiver, fromToken, path, minimumReceive);
     }
+
+    @Payable
+    public void fallback() {
+        only(dex);
+    }
 }

--- a/core-contracts/Router/src/test/java/network/balanced/score/core/router/RouterTest.java
+++ b/core-contracts/Router/src/test/java/network/balanced/score/core/router/RouterTest.java
@@ -220,6 +220,21 @@ class RouterTest extends TestBase {
         contextMock.verify(() -> Context.transfer(newReceiver, BigInteger.TEN));
     }
 
+    @Test
+    void fallback() {
+        setup();
+
+        Account nonDex = sm.createAccount();
+        nonDex.addBalance("ICX", BigInteger.TEN);
+        Executable nonDexCall = () -> sm.transfer(nonDex, routerScore.getAddress(), BigInteger.TEN);
+        String expectedErrorMessage = "Authorization Check: Authorization failed. Caller: " + nonDex.getAddress() +
+                " Authorized Caller: " + dexScore.getAddress();
+        expectErrorMessage(nonDexCall, expectedErrorMessage);
+
+        dexScore.addBalance("ICX", BigInteger.TEN);
+        sm.transfer(dexScore, routerScore.getAddress(), BigInteger.TEN);
+    }
+
     @AfterEach
     void contextClose() {
         contextMock.close();

--- a/score-lib/src/main/java/network/balanced/score/lib/interfaces/base/Fallback.java
+++ b/score-lib/src/main/java/network/balanced/score/lib/interfaces/base/Fallback.java
@@ -14,23 +14,12 @@
  * limitations under the License.
  */
 
-package network.balanced.score.lib.interfaces;
+package network.balanced.score.lib.interfaces.base;
 
-import network.balanced.score.lib.interfaces.addresses.*;
-import network.balanced.score.lib.interfaces.base.Fallback;
-import network.balanced.score.lib.interfaces.base.Name;
-import network.balanced.score.lib.interfaces.base.TokenFallback;
-import score.Address;
-import score.annotation.External;
-import score.annotation.Optional;
 import score.annotation.Payable;
 
-import java.math.BigInteger;
-
-public interface Router extends Name, GovernanceAddress, AdminAddress, DexAddress, SicxAddress, StakingAddress,
-        TokenFallback, Fallback {
+public interface Fallback {
 
     @Payable
-    @External
-    void route(Address[] path, @Optional BigInteger _minReceive);
+    void fallback();
 }


### PR DESCRIPTION
Accept icx from dex only and reject from other scores. Use route method to send icx and perform trade.