### PR TITLE
Fix the key name for dictdb for EnumerableSetDB to be same as python

### DIFF
--- a/score-lib/src/main/java/network/balanced/score/lib/utils/EnumerableSetDB.java
+++ b/score-lib/src/main/java/network/balanced/score/lib/utils/EnumerableSetDB.java
@@ -28,7 +28,7 @@ public class EnumerableSetDB<V> {
         // array of valueClass
         this.entries = Context.newArrayDB(varKey + "_es_entries", valueClass);
         // value => array index
-        this.indexes = Context.newDictDB(varKey + "_es_index", Integer.class);
+        this.indexes = Context.newDictDB(varKey + "_es_indexes", Integer.class);
     }
 
     public int length() {


### PR DESCRIPTION
Python: {var_key}_es_indexes

Java: varKey + "_es_index" (Error)
Fixed:
Java: varKey + "_es_indexes"