### PR TITLE
Keep the data parameter optional in router contract

### DIFF
--- a/core-contracts/Router/build.gradle
+++ b/core-contracts/Router/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id 'java'
 }
 
-version '0.1.0'
+version '0.1.1'
 
 repositories {
     mavenCentral()

--- a/core-contracts/Router/src/main/java/network/balanced/score/core/router/RouterImpl.java
+++ b/core-contracts/Router/src/main/java/network/balanced/score/core/router/RouterImpl.java
@@ -162,7 +162,7 @@ public class RouterImpl implements Router {
             BigInteger balance = (BigInteger) Context.call(currentToken, "balanceOf", Context.getAddress());
             Context.require(balance.compareTo(_minReceive) >= 0,
                     TAG + ": Below minimum receive amount of " + _minReceive);
-            Context.call(currentToken, "transfer", from, balance, new byte[0]);
+            Context.call(currentToken, "transfer", from, balance);
         }
     }
 

--- a/core-contracts/Router/src/test/java/network/balanced/score/core/router/RouterTest.java
+++ b/core-contracts/Router/src/test/java/network/balanced/score/core/router/RouterTest.java
@@ -126,6 +126,8 @@ class RouterTest extends TestBase {
         contextMock.when(() -> Context.call(sicxScore.getAddress(), "balanceOf", routerScore.getAddress())).thenReturn(icxToTrade);
         contextMock.when(() -> Context.call(any(Address.class), eq("transfer"), any(Address.class),
                 any(BigInteger.class), any(byte[].class))).thenReturn(null);
+        contextMock.when(() -> Context.call(any(Address.class), eq("transfer"), any(Address.class),
+                any(BigInteger.class))).thenReturn(null);
         Address[] path = new Address[]{sicxScore.getAddress()};
 
         Executable lessThanMinimumReceivable = () -> sm.call(owner, icxToTrade, routerScore.getAddress(), "route",
@@ -134,8 +136,7 @@ class RouterTest extends TestBase {
         expectErrorMessage(lessThanMinimumReceivable, expectedErrorMessage);
 
         sm.call(owner, icxToTrade, routerScore.getAddress(), "route", path, BigInteger.ZERO);
-        contextMock.verify(() -> Context.call(sicxScore.getAddress(), "transfer", owner.getAddress(), icxToTrade,
-                new byte[0]));
+        contextMock.verify(() -> Context.call(sicxScore.getAddress(), "transfer", owner.getAddress(), icxToTrade));
 
         Executable negativeMinimumBalance = () -> sm.call(owner, icxToTrade, routerScore.getAddress(),
                 "route", path, icxToTrade.negate());
@@ -201,6 +202,8 @@ class RouterTest extends TestBase {
         contextMock.reset();
         contextMock.when(() -> Context.transfer(any(Address.class), any(BigInteger.class))).then(invocationOnMock -> null);
         contextMock.when(() -> Context.call(any(Address.class), eq("balanceOf"), eq(routerScore.getAddress()))).thenReturn(BigInteger.TEN);
+        contextMock.when(() -> Context.call(any(Address.class), eq("transfer"), any(Address.class),
+                any(BigInteger.class))).thenReturn(null);
         contextMock.when(() -> Context.call(any(Address.class), eq("transfer"), any(Address.class),
                 any(BigInteger.class), any(byte[].class))).thenReturn(null);
         contextMock.when(() -> Context.getBalance(routerScore.getAddress())).thenReturn(BigInteger.TEN);


### PR DESCRIPTION
Previously the token contracts were sending data as b'None' in absence of data, but in java contracts we are sending new byte[0]. This create issues in contracts which haven't handled the empty byte array.
