### PR TITLE
Remove-onlyOwner()-from-setVoteDuration

### DIFF
--- a/core-contracts/Governance/src/main/java/network/balanced/score/core/governance/GovernanceImpl.java
+++ b/core-contracts/Governance/src/main/java/network/balanced/score/core/governance/GovernanceImpl.java
@@ -93,7 +93,6 @@ public class GovernanceImpl {
 
     @External
     public void setVoteDuration(BigInteger duration) {
-        onlyOwner();
         _setVoteDuration(duration);
     }
 


### PR DESCRIPTION
During translation, setVoteDuration was accidentally set to onlyOwner. This removes that restriction