### PR TITLE
remove _repay param requirement check

### DIFF
--- a/core-contracts/Loans/src/main/java/network/balanced/score/core/loans/LoansImpl.java
+++ b/core-contracts/Loans/src/main/java/network/balanced/score/core/loans/LoansImpl.java
@@ -527,7 +527,6 @@ public class LoansImpl implements Loans {
         Context.require(assetContract.balanceOf(from).compareTo(_value) >= 0, TAG + ": Insufficient balance.");
         Context.require(PositionsDB.hasPosition(from), TAG + ": No debt repaid because, " + from + " does not have a " +
                 "position in Balanced");
-        Context.require(_repay, TAG + ": No debt repaid because, repay=false");
 
         boolean newDay = checkForNewDay();
         BigInteger day = _getDay();


### PR DESCRIPTION
Removing the line that reverts if the _repay parameter is False. _repay is now unused in the returnAsset method.