### PR TITLE
feat: Add a configurable minimum floor to balanced floor limits.

### DIFF
--- a/core-contracts/Loans/src/intTest/java/network/balanced/score/core/loans/LoansIntegrationTest.java
+++ b/core-contracts/Loans/src/intTest/java/network/balanced/score/core/loans/LoansIntegrationTest.java
@@ -21,7 +21,6 @@ import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import foundation.icon.jsonrpc.Address;
 import foundation.icon.score.client.RevertedException;
-import network.balanced.score.lib.interfaces.Governance;
 import network.balanced.score.lib.test.integration.Balanced;
 import network.balanced.score.lib.test.integration.BalancedClient;
 import network.balanced.score.lib.test.integration.ScoreIntegrationTest;
@@ -478,6 +477,14 @@ abstract class LoansIntegrationTest implements ScoreIntegrationTest {
                 .add(createTransaction(balanced.loans._address(), "setTimeDelayMicroSeconds", setTimeDelay));
         owner.governance.execute(actions.toString());
 
+        JsonObject param = new JsonObject()
+            .add("type", "Address[]")
+            .add("value",  new JsonArray().add(balanced.sicx._address().toString()));
+        JsonArray enableFloors = new JsonArray()
+            .add(param);
+        actions = new JsonArray()
+                .add(createTransaction(balanced.loans._address(), "enableFloors", enableFloors));
+        owner.governance.execute(actions.toString());
 
         // Assert
         assertThrows(UserRevertedException.class, () ->

--- a/score-lib/src/main/java/network/balanced/score/lib/utils/FloorLimited.java
+++ b/score-lib/src/main/java/network/balanced/score/lib/utils/FloorLimited.java
@@ -2,10 +2,11 @@ package network.balanced.score.lib.utils;
 
 import java.math.BigInteger;
 
+import network.balanced.score.lib.interfaces.FloorLimitedInterface;
 import score.Address;
 import score.annotation.External;
 
-public abstract class FloorLimited {
+public abstract class FloorLimited implements FloorLimitedInterface {
     @External
     public void setFloorPercentage(BigInteger points) {
         Check.onlyGovernance();
@@ -26,6 +27,33 @@ public abstract class FloorLimited {
     @External(readonly = true)
     public BigInteger getTimeDelayMicroSeconds() {
         return BalancedFloorLimits.getTimeDelayMicroSeconds();
+    }
+
+    @External
+    public void enableFloors(Address[] tokens) {
+        Check.onlyGovernance();
+        for (Address token: tokens) {
+            BalancedFloorLimits.setDisabled(token, false);
+        }
+    }
+
+    @External
+    public void disableFloors(Address[] tokens) {
+        Check.onlyGovernance();
+        for (Address token: tokens) {
+            BalancedFloorLimits.setDisabled(token, true);
+        }
+    }
+
+    @External
+    public void setMinimumFloor(Address token, BigInteger minFloor) {
+        Check.onlyGovernance();
+        BalancedFloorLimits.setMinimumFloor(token, minFloor);
+    }
+
+    @External(readonly = true)
+    public BigInteger getMinimumFloor(Address token) {
+        return BalancedFloorLimits.getMinimumFloor(token);
     }
 
     @External


### PR DESCRIPTION
Add a configurable minimum floor to balanced floor limits and also disable all tokens by default so you have to explicitly state what tokens to protect